### PR TITLE
Kanishka cluster outage notification

### DIFF
--- a/databrary-backend-design-reviews/outageNotifications.hs
+++ b/databrary-backend-design-reviews/outageNotifications.hs
@@ -1,4 +1,15 @@
-type UserNoticeMessage = String
+{-
+existing type:
+module D.S.Types
+
+data Service = Service
+  { serviceStartTime :: !Timestamp
+  ...
+  , serviceDown :: !(Maybe T.Text)
+  }
+-}
+
+type UserNoticeMessage = String -- notification message will be propagated to the front end for display.
 
 -- | Mutually exclusive service levels
 data ServiceLevel = 
@@ -6,16 +17,69 @@ data ServiceLevel =
    | DegradedTranscodingDown UserNoticeMessage
    | FullyOperational
   deriving (Ord)
- 
- -- | 
- data TranscodingServiceLevel = TranscodingDown | FullyOperational
+
+data Service = Service
+  { serviceStartTime :: !Timestamp
+  ...
+  , serviceLevel :: !ServiceLevel
+  }
+
+{- existing initialization logic:
+module D.S.Init
+
+initService
+    :: Bool -- ^ Run in foreground?
+    -> C.Config
+    -> IO Service
+initService fg conf = do
+  time <- getCurrentTime
+  ...
+  storage <- initStorage (conf C.! "store")
+  let rc = Service
+        { serviceStartTime = time
+        ...
+        , serviceStorage = storage
+        ...
+        , serviceDown = conf C.! "store.DOWN"
+        }
+  return $! rc
+    { servicePeriodic = periodic
+    }
+
+module D.Store.Service
+
+initStorage :: C.Config -> IO Storage
+initStorage conf
+  | Just down <- conf C.! "DOWN" = return $ error $ "Storage unavailable: " ++ down
+  | otherwise = do
+      ...
+      
+      tc <- initTranscoder (conf C.! "transcode")
+
+      return $ Storage
+        { storageMaster = master
+        ...
+        , storageTranscoder = tc
+        }
+        
+module D.Store.Transcoder
+
+initTranscoder :: C.Config -> IO (Maybe Transcoder)
+initTranscoder conf =
+  ...
+  Just <$> do
+      ...
+      (r, out, err) <- runTranscoder t ["-t"]
+      case r of
+        ExitSuccess -> return t
+        ExitFailure e -> fail $ "initTranscoder test: " ++ show e ++ "\n" ++ out ++ err
+-}
+
+data TranscodingServiceLevel = TranscodingDown | FullyOperational
    deriving (Ord)
- 
- data StorageServiceLevel = StorageDown | FullyOperational
-   deriving (Ord)
- 
- -- utiity used during transcoding init
- 
- 
- -- utility used during storage init
- 
+
+initStorage :: C.Config -> ServiceLevel -> IO Storage
+
+-- initStorage will now branch on ServiceLevel.
+
+initTranscoder :: C.Config -> TranscodingServiceLevel -> IO (Maybe Transcoder)

--- a/databrary-backend-design-reviews/outageNotifications.hs
+++ b/databrary-backend-design-reviews/outageNotifications.hs
@@ -1,0 +1,21 @@
+type UserNoticeMessage = String
+
+-- | Mutually exclusive service levels
+data ServiceLevel = 
+     DegradedStorageDown UserNoticeMesage
+   | DegradedTranscodingDown UserNoticeMessage
+   | FullyOperational
+  deriving (Ord)
+ 
+ -- | 
+ data TranscodingServiceLevel = TranscodingDown | FullyOperational
+   deriving (Ord)
+ 
+ data StorageServiceLevel = StorageDown | FullyOperational
+   deriving (Ord)
+ 
+ -- utiity used during transcoding init
+ 
+ 
+ -- utility used during storage init
+ 


### PR DESCRIPTION
This is an interim design for generalizing the mechanism for starting databrary at a degraded service level. Eventually, it would be nice to move this from a toggle in a config file, to a runtime detection that changes its status automatically.

It's also desired to have a more complex change in generation of the angular constants at startup, but I am avoiding that for now.

Ideally, we focus any energy on making transcoding and storage more resilient to failures, instead of making the failure notification better.

----

This was tedious to setup, I'm going to shift over to databrary for the next review I attempt. Doing this in databrary would also help in making an easier to read diff.